### PR TITLE
It should generate an eTag which is just the MD5 of the file for a non-multipart upload file when file size is smaller than the part size

### DIFF
--- a/src/s3Etag.ts
+++ b/src/s3Etag.ts
@@ -13,10 +13,11 @@ function md5(contents: string | BinaryLike): string {
 }
 
 export function generateETag(filePath: string, partSizeInBytes = 0): string {
-  if (partSizeInBytes === 0) {
+  const { size: fileSizeInBytes } = fs.statSync(filePath);
+
+  if (partSizeInBytes === 0 || fileSizeInBytes <= partSizeInBytes) {
     return md5(fs.readFileSync(filePath));
   }
-  const { size: fileSizeInBytes } = fs.statSync(filePath);
   let parts = Math.floor(fileSizeInBytes / partSizeInBytes);
   if (fileSizeInBytes % partSizeInBytes > 0) {
     parts += 1;

--- a/src/tests/s3ETag.test.ts
+++ b/src/tests/s3ETag.test.ts
@@ -16,4 +16,9 @@ describe('s3ETag', () => {
     const etag = generateETag(stylesFilePath, 10);
     expect(etag).toBe('b8ffa274b982363604db211ee8ffb991-3');
   });
+
+  it('should generate an eTag which is just the MD5 of the file for a non-multipart upload file when file size is smaller than the part size ', () => {
+    const etag = generateETag(stylesFilePath, 2048);
+    expect(etag).not.toContain('-');
+  });
 });


### PR DESCRIPTION
Fixes #215